### PR TITLE
Refatora configuração do CI no gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ variables:
   COMPOSE_CMD: docker-compose -f docker-compose.yml -f deploy/prod.yml
 
 before_script:
+  - apk add --no-cache docker-compose
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   - export API_IMAGE_TAG=$CONTAINER_TEST_IMAGE
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
 
 variables:
   DOCKER_HOST: tcp://docker:2375/
+  CONTAINER_TEST_IMAGE: $CI_REGISTRY_IMAGE:gitlab-ci-dev	
   COMPOSE_CMD: docker-compose -f docker-compose.yml -f deploy/prod.yml
 
 before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: agoradigital/frontend-cicd:latest
+image: agoradigital/backend-cicd:latest
 
 services:
   - docker:dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,22 +6,12 @@ services:
 stages:
   - build
   - test
-  - release
-  - deploy
 
 variables:
-  DOCKER_HOST: tcp://docker:2375/
-  DOCKER_DRIVER: overlay2
-  # CONTAINER_TEST_IMAGE: $CI_PROJECT_NAME:dev
-  # CONTAINER_RELEASE_IMAGE: $CI_PROJECT_NAME
-  CONTAINER_TEST_IMAGE: $CI_REGISTRY_IMAGE:gitlab-ci-dev
-  CONTAINER_RELEASE_IMAGE: $CI_REGISTRY_IMAGE:gitlab-ci
   COMPOSE_CMD: docker-compose -f docker-compose.yml -f deploy/prod.yml
-  DOCKER_TLS_CERTDIR: ""
 
 before_script:
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-  - export API_IMAGE_TAG=$CONTAINER_TEST_IMAGE
 
 build:
   stage: build
@@ -36,19 +26,3 @@ tests:
     - $COMPOSE_CMD pull
     - $COMPOSE_CMD run api sh -c './manage.py test_all'
   coverage: '/TOTAL.+ ([0-9]{1,3}%)/'
-
-release-image:
-  stage: release
-  script:
-    - $COMPOSE_CMD pull
-    - docker tag $CONTAINER_TEST_IMAGE $CONTAINER_RELEASE_IMAGE
-    - docker push $CONTAINER_RELEASE_IMAGE
-  only:
-    - master
-
-deploy:
-  stage: deploy
-  script:
-    - curl --fail -XPOST "$DEPLOY_WEBHOOK"
-  only:
-    - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,5 @@
+image: docker:latest
+
 services:
   - docker:dind
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,3 @@
-image: agoradigital/backend-cicd:latest
-
 services:
   - docker:dind
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,10 +8,12 @@ stages:
   - test
 
 variables:
+  DOCKER_HOST: tcp://docker:2375/
   COMPOSE_CMD: docker-compose -f docker-compose.yml -f deploy/prod.yml
 
 before_script:
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+  - export API_IMAGE_TAG=$CONTAINER_TEST_IMAGE
 
 build:
   stage: build


### PR DESCRIPTION
## Mudanças
- Torna pipeline do CI no gitlab mais eficiente:
  + Remove passos desnecessários (release e deploy, que eram usados quando usávamos o Portainer pra fazer o deploy da aplicação a partir da VM)
  + Remove variáveis desnecessárias (que eram usadas nos passos removidos ou que eram redundantes)
  + Deixa apenas etapa de build e a de teste.
  + Corrige nome da imagem do pipeline

## Como Testar
- O teste que valida o pipeline é o resultado da execução no gitlab. Se ele cumpre os requisitos necessários (build e teste) e passa no gitlab, então está ok.