### PR TITLE
Remove filtro de interesses no endpoint dos eventos da tramitação

### DIFF
--- a/api/views/tramitacao_serializer.py
+++ b/api/views/tramitacao_serializer.py
@@ -62,14 +62,9 @@ class TramitacaoEventList(generics.ListAPIView):
         data_fim = self.request.query_params.get('data_fim', None)
         nivel = self.request.query_params.get('nivel', 100)
         ultimos_n = self.request.query_params.get('ultimos_n', 100)
-        interesseArg = self.request.query_params.get('interesse', 'leggo')
 
         data_inicio_dt = None
         data_fim_dt = None
-
-        if interesseArg is not None:
-            queryset = queryset.filter(
-                etapa_proposicao__proposicao__interesse__interesse=interesseArg)
 
         try:
             if data_inicio is not None:


### PR DESCRIPTION
## Mudanças
- Remove filtro de interesses no endpoint dos eventos da tramitação
- Corrige não aparecimento dos últimos eventos na página da proposição

## Flags 
- Pode ser avaliado com os dados gerados pela VM do projeto. ($ make update-data-remote)