### PR TITLE
Altera ordenação dos eventos como critério de recuperação de últimos eventos

### DIFF
--- a/api/views/tramitacao_serializer.py
+++ b/api/views/tramitacao_serializer.py
@@ -91,12 +91,14 @@ class TramitacaoEventList(generics.ListAPIView):
         if data_inicio_dt is not None:
             queryset = queryset.filter(data__gte=data_inicio_dt)
 
-        queryset = queryset.order_by('-data').filter(data__lte=data_fim_dt)
+        queryset = queryset.filter(data__lte=data_fim_dt)
 
         if nivel:
-            queryset = queryset.filter(nivel__lte=nivel)
+            queryset = queryset.order_by('nivel', '-data').filter(nivel__lte=nivel)
 
         if ultimos_n is not None:
             queryset = queryset[:int(ultimos_n)]
+
+        queryset = sorted(queryset, key=lambda x: x.data, reverse=True)
 
         return queryset

--- a/api/views/tramitacao_serializer.py
+++ b/api/views/tramitacao_serializer.py
@@ -62,7 +62,7 @@ class TramitacaoEventList(generics.ListAPIView):
         data_fim = self.request.query_params.get('data_fim', None)
         nivel = self.request.query_params.get('nivel', 100)
         ultimos_n = self.request.query_params.get('ultimos_n', 100)
-        interesseArg = self.request.query_params.get('interesse', 'leggo')
+        interesseArg = self.request.query_params.get('interesse', None)
 
         data_inicio_dt = None
         data_fim_dt = None


### PR DESCRIPTION
## Mudanças
- Altera ordenação dos eventos como critério para seleção dos últimos eventos. Caso o nível for passado como parâmetro serão recuperados os últimos eventos com menor nível (mais relevantes) considerando o número de eventos que se quer retornar (também passado como parâmetro). Ao final do corte (ultimos_n) os itens são ordenados em ordem decrescente de data. Antes deste PR o critério considerada apenas a data como ordenação antes do corte (dessa forma eventos mais relevantes eram deixados de fora caso fossem mais antigos).

A diferença de ordenação por de ser observada comparando os endpoints:
- com as mudanças (http://localhost:8000/eventos_tramitacao/senado/141443?data_fim=2020-04-27&nivel=3&ultimos_n=4): os eventos retornados consideram primeiramente o nível para preenchimento da lista dos últimos 4 eventos.
- sem as mudanças/versão atual (http://dev.api.leggo.org.br/eventos_tramitacao/senado/141443?data_fim=2020-04-27&nivel=3&ultimos_n=4): os eventos retornados consideram apenas a data como ordenação.

## Flags
- Depende da aprovação do PR https://github.com/parlametria/leggo-backend/pull/174