### PR TITLE
Modifica id da proposição presente nos eventos de tramitação

### DIFF
--- a/api/model/emenda.py
+++ b/api/model/emenda.py
@@ -14,9 +14,9 @@ class Emendas(models.Model):
     codigo_emenda = models.TextField(blank=True,
                                      help_text='Código da emenda na casa correspondente')
 
-    distancia = models.FloatField(null=True,
-                                  help_text='Distância calculada entre a emenda e o texto\
-                                    original')
+    distancia = models.FloatField(
+        null=True,
+        help_text='Distância calculada entre a emenda e o texto original')
 
     local = models.TextField(blank=True,
                              help_text='Local de apresentação da emenda')

--- a/api/model/tramitacao_event.py
+++ b/api/model/tramitacao_event.py
@@ -41,7 +41,7 @@ class TramitacaoEvent(models.Model):
 
     @property
     def proposicao_id(self):
-        '''ID da proposição leggo a qual esse evento se refere.'''
+        '''ID da proposição no sistema leggo a qual esse evento se refere.'''
         return self.etapa_proposicao.proposicao.id_leggo
 
     @property

--- a/api/model/tramitacao_event.py
+++ b/api/model/tramitacao_event.py
@@ -41,8 +41,8 @@ class TramitacaoEvent(models.Model):
 
     @property
     def proposicao_id(self):
-        '''ID da proposição a qual esse evento se refere.'''
-        return self.etapa_proposicao.proposicao_id
+        '''ID da proposição leggo a qual esse evento se refere.'''
+        return self.etapa_proposicao.proposicao.id_leggo
 
     @property
     def proposicao(self):


### PR DESCRIPTION
## Mudanças
- Antes o id retornado era o id interno gerado pelo BD. Agora o id retornado é o id_leggo, que é o esperado pelo frontend (usado para pesquisa das proposições).
- Esta mudança resolve o problema de exibição dos últimos eventos na página inicial da Agenda.