### PR TITLE
Adiciona endpoint para recuperar temperatura máxima

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -100,7 +100,15 @@ def create_proposicao(self):
         proposicao=proposicao
     )
 
+    temperatura2 = TemperaturaHistorico(
+        temperatura_periodo=0,
+        temperatura_recente=1.37,
+        periodo='2018-06-15',
+        proposicao=proposicao
+    )
+
     temperatura.save()
+    temperatura2.save()
 
     self.proposicao = proposicao
     self.etapa_proposicao = etapa_proposicao

--- a/api/tests.py
+++ b/api/tests.py
@@ -4,6 +4,7 @@ from api.model.etapa_proposicao import EtapaProposicao
 from api.model.proposicao import Proposicao
 from api.model.temperatura_historico import TemperaturaHistorico
 from api.model.interesse import Interesse
+import json
 
 
 class ProposicaoTests(APITestCase):
@@ -92,6 +93,15 @@ def create_proposicao(self):
     )
     interesse.save()
 
+    temperatura = TemperaturaHistorico(
+        temperatura_periodo=1.25,
+        temperatura_recente=1.67,
+        periodo='2018-06-08',
+        proposicao=proposicao
+    )
+
+    temperatura.save()
+
     self.proposicao = proposicao
     self.etapa_proposicao = etapa_proposicao
 
@@ -110,3 +120,46 @@ def create_temperatura(self, proposicao):
     temperatura.save()
 
     self.temperatura = temperatura
+
+
+class TemperaturaTests(APITestCase):
+    def setUp(self):
+        create_proposicao(self)
+        self.url = '/temperatura/max/'
+
+    def test_temperatura_max(self):
+        '''
+        Check maximum temperature value
+        '''
+        response = self.client.get(self.url)
+        res = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(res['max_temperatura_periodo'], 1.67)
+
+    def test_invalid_date(self):
+        '''
+        Check invalid date
+        '''
+        response = self.client.get(self.url + '?data_inicio=2020-01-50')
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_final_date(self):
+        '''
+        Check invalid date
+        '''
+        response = self.client.get(self.url + '?data_fim=2020-01-500')
+
+        # Usa a data atual como default em caso de erro com a data de parâmetro
+        self.assertEqual(response.status_code, 200)
+
+    def test_init_date(self):
+        '''
+        Check invalid date
+        '''
+        response = self.client.get(self.url + '?data_inicio=2018-06-08')
+        res = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(res['max_temperatura_periodo'], 1.67)

--- a/api/urls.py
+++ b/api/urls.py
@@ -14,6 +14,7 @@ from api.views.coautoria_node_serializer import CoautoriaNodeList
 from api.views.coautoria_edge_serializer import CoautoriaEdgeList
 from api.views.autoria_serializer import AutoriaList
 from api.views.interesse_serializer import InteresseList
+from api.views.temperatura_historico_serializer import TemperaturaMaxPeriodo
 
 
 # router = DefaultRouter()
@@ -50,4 +51,5 @@ urlpatterns = [
         AutoriaList.as_view()),
     url(r'^interesses/(?P<id>[0-9]+)/?$',
         InteresseList.as_view()),
+    url(r'^temperatura/max/?$', TemperaturaMaxPeriodo.as_view()),
 ]

--- a/api/views/temperatura_historico_serializer.py
+++ b/api/views/temperatura_historico_serializer.py
@@ -1,8 +1,60 @@
+from django.db.models import Max
+from django.http import JsonResponse
 from rest_framework import serializers
+from rest_framework.views import APIView
+from datetime import datetime
 from api.model.temperatura_historico import TemperaturaHistorico
+from rest_framework import status
 
 
 class TemperaturaHistoricoSerializer(serializers.ModelSerializer):
     class Meta:
         model = TemperaturaHistorico
         fields = ('periodo', 'temperatura_recente', 'temperatura_periodo')
+
+
+class TemperaturaMaxPeriodo(APIView):
+    '''
+    Calcula a temperatura máxima entre as proposições de um interesse.
+    Pode receber como parâmetro o intervalo de tempo usado para o cálculo.
+    '''
+
+    def get(self, request, format=None):
+
+        interesseArg = self.request.query_params.get('interesse', 'leggo')
+        data_inicio = self.request.query_params.get('data_inicio', None)
+        data_fim = self.request.query_params.get('data_fim', None)
+
+        data_inicio_processada = None
+        data_fim_processada = None
+
+        try:
+            if data_inicio is not None:
+                data_inicio_processada = datetime.strptime(data_inicio, '%Y-%m-%d')
+        except ValueError:
+            return JsonResponse(
+                {'error': f'Data de início ({data_inicio}) inválida.'
+                 'Formato correto: yyyy-mm-dd'},
+                status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            data_fim_processada = (
+                datetime.today() if data_fim is None else datetime.strptime(
+                    data_fim, '%Y-%m-%d'))
+        except ValueError:
+            print(
+                f'Data de fim ({data_fim}) inválida. '
+                'Utilizando data atual como data de fim.')
+            data_fim_processada = datetime.today()
+
+        queryset = TemperaturaHistorico.objects.filter(
+            proposicao__interesse__interesse=interesseArg)
+
+        if data_inicio_processada is not None:
+            queryset = queryset.filter(periodo__gte=data_inicio_processada)
+
+        queryset = queryset.filter(periodo__lte=data_fim_processada)
+
+        queryset = queryset.aggregate(max_temperatura_periodo=Max('temperatura_recente'))
+
+        return JsonResponse(queryset, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Mudanças
- Adiciona endpoint que recupera a temperatura máxima de um interesse em um intervalo de tempo.

**Exemplo:**
http://localhost:8000/temperatura/max?interesse=leggo&data_inicio=2020-03-01&data_final=2020-05-01

- O parâmetro interesse é opcional e o default é 'leggo'
- data_inicio também é opcional e o default é a data mínima com temperatura calculada
- data_final também é opcional e o default é a data atual
- data_inicio e data_final devem estar no formato: 'yyyy-mm-dd'


