### PR TITLE
Adiciona endpoint para recuperar informações de um parlamentar específico

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -13,8 +13,7 @@ from api.views.ator_serializer import (
     AtoresAgregadosList,
     AtoresProposicaoList,
     AtoresRelatoriasList,
-    AtoresRelatoriasDetalhada,
-    AtorList,
+    AtoresRelatoriasDetalhada
 )
 from api.views.pressao_serializer import PressaoList
 from api.views.coautoria_node_serializer import CoautoriaNodeList
@@ -46,7 +45,7 @@ from api.views.peso_politico_serializer import (
     PesoPoliticoParlamentar,
 )
 from api.views.entidade_serializer import (
-    EntidadeList, 
+    EntidadeList,
     ParlamentaresExercicioList,
     AtorEntidadeInfo
 )

--- a/api/urls.py
+++ b/api/urls.py
@@ -45,7 +45,11 @@ from api.views.peso_politico_serializer import (
     PesoPoliticoLista,
     PesoPoliticoParlamentar,
 )
-from api.views.entidade_serializer import EntidadeList, ParlamentaresExercicioList
+from api.views.entidade_serializer import (
+    EntidadeList, 
+    ParlamentaresExercicioList,
+    AtorEntidadeInfo
+)
 from api.views.autores_proposicao_serializer import AutoresList
 
 
@@ -71,7 +75,7 @@ urlpatterns = [
     ),
     url(r"^pauta/(?P<casa>[a-z]+)/(?P<id_ext>[0-9]+)/?$", PautaList.as_view()),
     url(r"^emenda/(?P<casa>[a-z]+)/(?P<id_ext>[0-9]+)/?$", EmendasList.as_view()),
-    url(r"^ator/(?P<id_autor>[0-9]+)/?$", AtorList.as_view()),
+    url(r"^ator/(?P<id_autor>[0-9]+)/?$", AtorEntidadeInfo.as_view()),
     url(r"^atores/(?P<id_leggo>[0-9]+)/?$", AtoresProposicaoList.as_view()),
     url(r"^atores/relatorias/?$", AtoresRelatoriasList.as_view()),
     url(r"^atores/agregados/?$", AtoresAgregadosList.as_view()),

--- a/api/views/entidade_serializer.py
+++ b/api/views/entidade_serializer.py
@@ -143,3 +143,40 @@ class RelatorSerializer(serializers.ModelSerializer):
             "uf",
             "em_exercicio",
         )
+
+
+class AtorEntidadeSerializer(serializers.ModelSerializer):
+    id_autor = serializers.IntegerField(source="id_entidade")
+    id_autor_parlametria = serializers.IntegerField(source="id_entidade_parlametria")
+    nome_autor = serializers.CharField(source="nome")
+    casa_autor = serializers.CharField(source="casa")
+
+    class Meta:
+        model = Entidade
+        fields = (
+            "id_autor",
+            "id_autor_parlametria",
+            "nome_autor",
+            "partido",
+            "uf",
+            "casa_autor"
+        )
+
+
+class AtorEntidadeInfo(generics.ListAPIView):
+    """
+    Retorna informações específicas de um parlamentar como nome, uf e partido
+    """
+
+    serializer_class = AtorEntidadeSerializer
+
+    def get_queryset(self):
+
+        id_autor_arg = self.kwargs["id_autor"]
+
+        queryset = (
+            Entidade.objects.filter(id_entidade_parlametria=id_autor_arg)
+            .order_by("-legislatura")
+        )[:1]
+
+        return queryset


### PR DESCRIPTION
## Mudanças
- Adiciona endpoint para recuperar informações de um parlamentar específico

## Flags
- Resolve o bug que ocorre em parlamentares que não possuem entradas na tabela de atores mas que deveriam ter informações na sua página detalhada. Exemplo: Cid Gomes (https://leggo-painel.parlametria.org.br/primeira-infancia/atores-chave/25973/atividades)