### PR TITLE
Adiciona endpoint que retorna a data da última anotação para todas as proposições de uma agenda

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -36,6 +36,7 @@ from api.views.anotacao_serializer import (
     AnotacaoListByProp,
     AnotacaoList,
     AnotacaoGeralList,
+    UltimaAnotacaoList
 )
 from api.views.temperatura_historico_serializer import (
     TemperaturaMaxPeriodo,
@@ -124,6 +125,7 @@ urlpatterns = [
     url(r"^coautorias_node/(?P<id>[a-z0-9]+)/?$", CoautoriaNodeList.as_view()),
     url(r"^coautorias_edge/(?P<id>[a-z0-9]+)/?$", CoautoriaEdgeList.as_view()),
     url(r"^interesses/(?P<id>[a-z0-9]+)/?$", InteresseList.as_view()),
+    url(r"^anotacoes/ultima/?$", UltimaAnotacaoList.as_view()),
     url(r"^anotacoes/(?P<id>[a-z0-9]+)/?$", AnotacaoListByProp.as_view()),
     url(r"^proposicoes/(?P<id>[a-z0-9]+)/?$", ProposicaoDetail.as_view()),
     url(r"^interesses/?$", InteresseByNome.as_view()),

--- a/api/views/proposicao_serializer.py
+++ b/api/views/proposicao_serializer.py
@@ -49,7 +49,6 @@ class ProposicaoSerializer(serializers.ModelSerializer):
             "resumo_progresso",
             "temperatura_coeficiente",
             "id_leggo",
-            "anotacao_data_ultima_modificacao",
             "sigla_camara",
             "sigla_senado"
         )


### PR DESCRIPTION
## Mudanças
- Adiciona endpoint que retorna a data da última anotação para todas as proposições de uma agenda

http://localhost:8000/anotacoes/ultima?interesse=congresso-remoto
http://localhost:8000/anotacoes/ultima?interesse=primeira-infancia
