### PR TITLE
Filtra o histórico da pressão de uma proposição por período

### DIFF
--- a/api/views/pressao_serializer.py
+++ b/api/views/pressao_serializer.py
@@ -1,4 +1,5 @@
-from rest_framework import serializers, generics
+from django.http import JsonResponse
+from rest_framework import serializers, generics, status
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 from datetime import datetime

--- a/api/views/pressao_serializer.py
+++ b/api/views/pressao_serializer.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers, generics
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
+from datetime import datetime
 from api.model.pressao import Pressao
 from api.utils.filters import get_filtered_interesses
 
@@ -26,24 +27,67 @@ class PressaoList(generics.ListAPIView):
     @swagger_auto_schema(
         manual_parameters=[
             openapi.Parameter(
-                'id_leggo', openapi.IN_PATH, 'id da proposição no sistema',
-                type=openapi.TYPE_INTEGER),
+                'id_leggo',
+                openapi.IN_PATH,
+                'id da proposição no sistema',
+                type=openapi.TYPE_INTEGER
+            ),
         ]
     )
     def get_queryset(self):
         '''
-        Retorna a pressão
+        Retorna a pressão de uma proposição de um interesse em um período
         '''
 
-        interesseArg = self.request.query_params.get('interesse')
-
-        # Adiciona interesse default
-        if interesseArg is None:
-            interesseArg = 'leggo'
-
         id_leggo = self.kwargs['id_leggo']
+        interesseArg = self.request.query_params.get('interesse')
+        data_inicio = self.request.query_params.get("data_inicio", None)
+        data_fim = self.request.query_params.get("data_fim", None)
+
+        interesses = get_filtered_interesses(interesseArg)
+
+        data_inicio_processada = None
+        data_fim_processada = None
+
+        try:
+            if data_inicio is not None:
+                data_inicio_processada = datetime.strptime(data_inicio, "%Y-%m-%d")
+        except ValueError:
+            return JsonResponse(
+                {
+                    "error": f"Data de início ({data_inicio}) inválida."
+                    "Formato correto: yyyy-mm-dd"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            data_fim_processada = (
+                datetime.today()
+                if data_fim is None
+                else datetime.strptime(data_fim, "%Y-%m-%d")
+            )
+        except ValueError:
+            print(
+                f"Data de fim ({data_fim}) inválida. "
+                "Utilizando data atual como data de fim."
+            )
+            data_fim_processada = datetime.today()
+
         queryset = Pressao.objects.filter(
             proposicao__id_leggo=id_leggo, interesse=interesseArg)
+
+        if data_inicio_processada is not None:
+            queryset = queryset.filter(date__gte=data_inicio_processada)
+
+        queryset = queryset.filter(date__lte=data_fim_processada)
+
+        queryset = (
+            queryset.filter(
+                proposicao__id_leggo__in=interesses.values("id_leggo")
+            )
+            .order_by("-date")
+        )
 
         return queryset
 


### PR DESCRIPTION
## Mudanças

O endpoint **/pressao/<id>** pode receber dois novos parâmetros não obrigatórios: **data_inicio** e **data_fim**
Exemplo: http://localhost:8000/pressao/d5d1a579ad8a7733803d6a477c34f121/?interesse=transparencia-e-integridade&data_inicio=2020-08-30&data_fim=2020-11-30

Obs.: O endpoint deve retornar todos os resultados até a data de hoje caso esses parâmetros não sejam setados.