### PR TITLE
Usa o cache do django em alguns endpoints específicos

### DIFF
--- a/agorapi/settings.py
+++ b/agorapi/settings.py
@@ -166,6 +166,8 @@ CORS_ORIGIN_ALLOW_ALL = True
 
 INTERNAL_IPS = ['127.0.0.1']
 
+CACHE_TTL = 60 * 60  # 1 hour
+
 if DEBUG:
     # tricks to have debug toolbar when developing with docker
     MIDDLEWARE.insert(1, 'debug_toolbar.middleware.DebugToolbarMiddleware')

--- a/agorapi/settings.py
+++ b/agorapi/settings.py
@@ -166,7 +166,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 
 INTERNAL_IPS = ['127.0.0.1']
 
-CACHE_TTL = 60 * 60  # 1 hour
+CACHE_TTL = 60 * 240  # 4 hours
 
 if DEBUG:
     # tricks to have debug toolbar when developing with docker

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,4 +1,7 @@
 from django.conf.urls import url  # , include
+from django.views.decorators.cache import cache_page
+from django.conf import settings
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
 
 # from rest_framework.routers import DefaultRouter
 from api.views.info_serializer import Info
@@ -73,10 +76,12 @@ from api.views.disciplina_serializer import DisciplinaList, DisciplinaParlamenta
 # router = DefaultRouter()
 # router.register(r'proposicoes', views.ProposicaoViewSet)
 
+CACHE_TTL = getattr(settings, 'CACHE_TTL', DEFAULT_TIMEOUT)
+
 urlpatterns = [
     # url(r'^', include(router.urls)),
     url(r"^info/?$", Info.as_view()),
-    url(r"^proposicoes/?$", ProposicaoList.as_view()),
+    url(r"^proposicoes/?$", cache_page(CACHE_TTL)(ProposicaoList.as_view())),
     url(r"^etapas/?$", EtapasList.as_view()),
     url(
         r"^eventos_tramitacao/(?P<casa>[a-z]+)/(?P<id_ext>[0-9]+)/?$",
@@ -87,7 +92,7 @@ urlpatterns = [
     url(r"^eventos_tramitacao/?$", TramitacaoEventList.as_view()),
     url(r"^proposicoes/(?P<id_ext>[0-9]+)/fases/?$", Info.as_view()),
     url(r"^progresso/(?P<id_leggo>[a-z0-9]+)/?$", ProgressoByID.as_view()),
-    url(r"^progresso/?$", ProgressoList.as_view()),
+    url(r"^progresso/?$", cache_page(CACHE_TTL)(ProgressoList.as_view())),
     url(
         r"^comissao/(?P<casa>[a-z]+)/(?P<sigla>([a-z]+|[A-Z]+)[0-9]*)/?$",
         ComissaoList.as_view(),
@@ -105,7 +110,8 @@ urlpatterns = [
         AtoresRelatoriasDetalhada.as_view(),
     ),
     url(r"^ator/(?P<id_autor>[0-9]+)/autorias/?$", AutoriasAutorList.as_view()),
-    url(r"^autorias/agregadas/?$", AutoriasAgregadasList.as_view()),
+    url(r"^autorias/agregadas/?$",
+        cache_page(CACHE_TTL)(AutoriasAgregadasList.as_view())),
     url(
         r"^autorias/agregadas/(?P<id_autor>[0-9]+)/?$",
         AutoriasAgregadasByAutor.as_view(),
@@ -119,7 +125,8 @@ urlpatterns = [
     url(r"^anotacoes/?$", AnotacaoList.as_view()),
     url(r"^anotacoes-gerais/?$", AnotacaoGeralList.as_view()),
     url(r"^temperatura/max/?$", TemperaturaMaxPeriodo.as_view()),
-    url(r"^temperatura/ultima/?$", UltimaTemperaturaList.as_view()),
+    url(r"^temperatura/ultima/?$",
+        cache_page(CACHE_TTL)(UltimaTemperaturaList.as_view())),
     url(r"^temperatura/(?P<id>[a-z0-9]+)/?$", TemperaturaPeriodoList.as_view()),
     url(r"^comissao/presidencia/?$", PresidenciaComissaoLista.as_view()),
     url(
@@ -144,7 +151,7 @@ urlpatterns = [
         AutoriasPorProposicaoList.as_view()),
     url(r"^autorias/(?P<id_leggo>[a-z0-9]+)/?$", AutoriaList.as_view()),
     url(r"^autorias/?$", AutoriasTabelaList.as_view()),
-    url(r"^pressao/ultima/?$", UltimaPressaoList.as_view()),
+    url(r"^pressao/ultima/?$", cache_page(CACHE_TTL)(UltimaPressaoList.as_view())),
     url(r"^pressao/(?P<id_leggo>[a-z0-9]+)/?$", PressaoList.as_view()),
     url(r"^coautorias_node/(?P<id>[a-z0-9]+)/?$", CoautoriaNodeList.as_view()),
     url(r"^coautorias_edge/(?P<id>[a-z0-9]+)/?$", CoautoriaEdgeList.as_view()),


### PR DESCRIPTION
## Mudanças
- Usa o cache do django em alguns endpoints específicos. O Cache tem um timeout de 1 hora (setado em settings.py)
- Foi escolhido o tipo de cache per view. Os motivos foram: 
1. a flexibilidade de aplicar em endpoints específicos.
2. a facilidade de configuração e uso.

O tipo de cache per view não é recomendado quando existe mais de um servidor para o backend por não ser escalável nesse sentido. Nesses casos recomenda-se usar o Redis ou Memcached, mas em ambos os casos será necessário configurar um servidor específico para cache.

Fontes: 
https://testdriven.io/blog/django-caching/
https://docs.djangoproject.com/en/3.0/topics/cache/#the-per-view-cache