### PR TITLE
Conserta fields em endpoint de autorias

### DIFF
--- a/api/views/autoria_serializer.py
+++ b/api/views/autoria_serializer.py
@@ -458,7 +458,7 @@ class AutoriasTabelaList(generics.ListAPIView):
             Autoria.objects
             .filter(id_leggo__in=interesses.values('id_leggo'),
                     data__gt='2019-01-31')
-            .distinct('id_autor, id_documento')
+            .distinct('id_autor', 'id_documento')
             .select_related('etapa_proposicao')
             .values('id_autor', 'casa_autor', 'id_documento', 'id_leggo',
                     'id_principal', 'casa',


### PR DESCRIPTION
# Mudanças

Conserta atual erro 500 no servidor no endpoint de autorias. Ex: [http://api.leggo.org.br/autorias?interesse=pandemia](http://api.leggo.org.br/autorias?interesse=pandemia).
